### PR TITLE
findOrCreate actually resolves to [Model,boolean]

### DIFF
--- a/4/lib/model.d.ts
+++ b/4/lib/model.d.ts
@@ -1952,8 +1952,8 @@ export abstract class Model {
    * Find a row that matches the query, or build (but don't save) the row if none is found.
    * The successfull result of the promise will be (instance, initialized) - Make sure to use .spread()
    */
-  static findOrInitialize(options: FindOrInitializeOptions): Promise<Model>;
-  static findOrBuild(options: FindOrInitializeOptions): Promise<Model>;
+  static findOrInitialize(options: FindOrInitializeOptions): Promise<[Model,boolean]>;
+  static findOrBuild(options: FindOrInitializeOptions): Promise<[Model,boolean]>;
 
   /**
    * Find a row that matches the query, or build and save the row if none is found
@@ -1966,7 +1966,7 @@ export abstract class Model {
    * an instance of sequelize.TimeoutError will be thrown instead. If a transaction is created, a savepoint
    * will be created instead, and any unique constraint violation will be handled internally.
    */
-  static findOrCreate(options: FindOrInitializeOptions): Promise<Model>;
+  static findOrCreate(options: FindOrInitializeOptions): Promise<[Model,boolean]>;
 
   /**
    * Insert or update a single row. An update will be executed if a row which matches the supplied values on

--- a/4/lib/model.d.ts
+++ b/4/lib/model.d.ts
@@ -1952,8 +1952,8 @@ export abstract class Model {
    * Find a row that matches the query, or build (but don't save) the row if none is found.
    * The successfull result of the promise will be (instance, initialized) - Make sure to use .spread()
    */
-  static findOrInitialize(options: FindOrInitializeOptions): Promise<[Model,boolean]>;
-  static findOrBuild(options: FindOrInitializeOptions): Promise<[Model,boolean]>;
+  static findOrInitialize(options: FindOrInitializeOptions): Promise<[Model, boolean]>;
+  static findOrBuild(options: FindOrInitializeOptions): Promise<[Model, boolean]>;
 
   /**
    * Find a row that matches the query, or build and save the row if none is found
@@ -1966,7 +1966,7 @@ export abstract class Model {
    * an instance of sequelize.TimeoutError will be thrown instead. If a transaction is created, a savepoint
    * will be created instead, and any unique constraint violation will be handled internally.
    */
-  static findOrCreate(options: FindOrInitializeOptions): Promise<[Model,boolean]>;
+  static findOrCreate(options: FindOrInitializeOptions): Promise<[Model, boolean]>;
 
   /**
    * Insert or update a single row. An update will be executed if a row which matches the supplied values on


### PR DESCRIPTION
In sequelize 4.0.0-2 (and presumably 4.0.0-1), `findOrCreate`, still resolves to `[Model,boolean]` and not just `Model`

Ironically, the documentation in `model.d.ts` [speaks](https://github.com/types/npm-sequelize/blob/053f98b2e88b725087930e76eb2360cfed94ecaa/4/lib/model.d.ts#L1953) of [this](https://github.com/types/npm-sequelize/blob/053f98b2e88b725087930e76eb2360cfed94ecaa/4/lib/model.d.ts#L1960), too.

`¯\_(ツ)_/¯`

The code in question: 
 - [findOrCreate](https://github.com/sequelize/sequelize/blob/master/lib/model.js#L1987-L2001)
 - [findOrBuild and findOrInitialize](https://github.com/sequelize/sequelize/blob/master/lib/model.js#L1946-L1960)