### PR TITLE
Export utils directly

### DIFF
--- a/4/lib/sequelize.d.ts
+++ b/4/lib/sequelize.d.ts
@@ -1272,5 +1272,6 @@ export {Promise} from './promise';
 export {Validator} from './utils/validator-extras';
 import * as Utils from './utils';
 export {Utils};
+export * from './utils';
 
 export default Sequelize;


### PR DESCRIPTION
Export everything from utils as well, because they are assigned on the exported sequelize object.